### PR TITLE
Deploy to Clojars without GPG signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lazy Tables
+# Lazy Tables [![Clojars Project](https://img.shields.io/clojars/v/com.workiva/lazy-tables.svg)](https://clojars.org/com.workiva/lazy-tables)
 
 A library for lazy relational algebra based on some [great work](https://dl.acm.org/citation.cfm?id=1706372) by Fritz Henglein
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva/lazy-tables "1.0.0"
+(defproject com.workiva/lazy-tables "0.1.0"
   :description "A set of tools for lazy relational algebra"
   :url "https://github.com/Workiva/lazy-tables"
   :license {:name "Apache License, Version 2.0"}
@@ -9,6 +9,11 @@
                  [org.clojure/math.combinatorics "0.1.4"]
                  [org.clojure/test.check "0.10.0-alpha3"]
                  [potemkin "0.4.5"]]
+
+  :deploy-repositories {"clojars"
+                        {:url "https://repo.clojars.org"
+                         :sign-releases false}}
+
   :source-paths      ["src"]
   :test-paths        ["test"]
 


### PR DESCRIPTION
## Description of Changes

  - Previous Artifacts have been deployed to Clojars without GPG signing, this overrides the default `lein deploy clojars` profile to not use GPG signing

## Proposed Testing Steps (If Applicable)

  -

## Relevant Issues (If Applicable)

  -

## Maintainer Notifications

  - @alexalegre-wf
