### PR TITLE
Release lazy-table 0.1.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.workiva/lazy-tables "0.1.0"
+(defproject com.workiva/lazy-tables "0.1.1"
   :description "A set of tools for lazy relational algebra"
   :url "https://github.com/Workiva/lazy-tables"
   :license {:name "Apache License, Version 2.0"}


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Initial Commit to OpenSource Repository](https://github.com/Workiva/lazy-tables/pull/1)
	* [Deploy to Clojars without GPG signing](https://github.com/Workiva/lazy-tables/pull/2)
	* [EVA-970 - Add CircleCI to lazy-tables](https://github.com/Workiva/lazy-tables/pull/3)
	* [EVA-973 Add Github Pages Documentation](https://github.com/Workiva/lazy-tables/pull/6)


Requested by: @tylerwilding-wk

Diff Between Last Tag and Proposed Release: N/A
Diff Between Last Tag and New Tag: N/A

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4655021031686144/logs/)